### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,21 +7,21 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SmartDial                      KEYWORD1
+SmartDial	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getPosition                    KEYWORD2
-center                         KEYWORD2
-reset                          KEYWORD2
-setAddress                     KEYWORD2
-setPosition                    KEYWORD2
-isButtonPressed                KEYWORD2
-getStates                      KEYWORD2
-getVersion                     KEYWORD2
-setBottomLimit                 KEYWORD2
-setTopLimit                    KEYWORD2
+getPosition	KEYWORD2
+center	KEYWORD2
+reset	KEYWORD2
+setAddress	KEYWORD2
+setPosition	KEYWORD2
+isButtonPressed	KEYWORD2
+getStates	KEYWORD2
+getVersion	KEYWORD2
+setBottomLimit	KEYWORD2
+setTopLimit	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords